### PR TITLE
Remove proxy subcommand and add import options

### DIFF
--- a/MTG_Importer.py
+++ b/MTG_Importer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Import ManaBox CSV data, including proxies, into SQL Server."""
+"""Import ManaBox CSV data into SQL Server."""
 
 import argparse
 import csv
@@ -106,7 +106,7 @@ def fetch_legendary(
 def read_rows(
     csv_path: str,
     location: str = "Bulk",
-    card_type: str = "Origional",
+    card_type: str = "Original",
     purchase_price_override: Optional[Decimal] = None,
 ):
     with open(csv_path, newline="", encoding="utf-8") as fh:
@@ -152,7 +152,7 @@ def import_csv(
     user: Optional[str] = None,
     password: Optional[str] = None,
     location: str = "Bulk",
-    card_type: str = "Origional",
+    card_type: str = "Original",
     purchase_price_override: Optional[Decimal] = None,
 ) -> None:
     rows = list(read_rows(path, location, card_type, purchase_price_override))
@@ -214,17 +214,16 @@ if __name__ == "__main__":
     imp_parser.add_argument("--database", default="MTG", help="Database name")
     imp_parser.add_argument("--user", help="Database user")
     imp_parser.add_argument("--password", help="Database password")
-
-    proxy_parser = subparsers.add_parser(
-        "import-proxies", help="Import proxy CSV into SQL Server"
+    imp_parser.add_argument("--location", default="Bulk", help="Location to store cards")
+    imp_parser.add_argument(
+        "--cardtype", default="Original", help="Value for CardType column"
     )
-    proxy_parser.add_argument("csv_file", help="Path to ManaBox CSV file")
-    proxy_parser.add_argument("--location", required=True, help="Location to store proxies")
-    proxy_parser.add_argument("--dry-run", action="store_true", help="Parse file but do not insert")
-    proxy_parser.add_argument("--server", help="SQL Server host[,port]")
-    proxy_parser.add_argument("--database", default="MTG", help="Database name")
-    proxy_parser.add_argument("--user", help="Database user")
-    proxy_parser.add_argument("--password", help="Database password")
+    imp_parser.add_argument(
+        "--setpurchaseprice",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use purchase price from CSV (disable with --no-setpurchaseprice)",
+    )
 
     leg_parser = subparsers.add_parser(
         "populate-legendary", help="Populate Legendary column for existing cards"
@@ -250,24 +249,11 @@ if __name__ == "__main__":
             args.database,
             args.user,
             args.password,
-        )
-    elif args.command == "import-proxies":
-        if not args.dry_run:
-            missing = [name for name in ("server", "user", "password") if getattr(args, name) is None]
-            if missing:
-                proxy_parser.error(
-                    "--server, --user, and --password are required unless --dry-run is specified"
-                )
-        import_csv(
-            args.csv_file,
-            args.dry_run,
-            args.server,
-            args.database,
-            args.user,
-            args.password,
             location=args.location,
-            card_type="BW Proxy",
-            purchase_price_override=Decimal("0"),
+            card_type=args.cardtype,
+            purchase_price_override=(
+                None if args.setpurchaseprice else Decimal("0")
+            ),
         )
     elif args.command == "populate-legendary":
         populate_legendary(args.server, args.database, args.user, args.password)

--- a/MTG_Importer.py
+++ b/MTG_Importer.py
@@ -4,6 +4,7 @@
 import argparse
 import csv
 import json
+from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import Optional, Dict, Tuple
 from urllib.error import URLError, HTTPError
@@ -45,8 +46,8 @@ INSERT_SQL = (
     INSERT INTO dbo.Cards
         (Name, SetCode, SetName, CollectorNumber, Foil, Rarity, Legendary, ManaBoxID,
          ScryfallID, PurchasePrice, Misprint, Altered, Condition, Language,
-         PurchasePriceCurrency, Location, CardType, DoubleSided)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         PurchasePriceCurrency, Location, CardType, DoubleSided, CreatedDate)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
 )
 
@@ -141,6 +142,7 @@ def read_rows(
                     location,
                     card_type,
                     1 if "//" in (row.get("Name") or "") else 0,
+                    datetime.now(),
                 )
 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # MTG-importer
 
 A simple script to import ManaBox CSV exports into the `MTG` SQL Server database.
-It also offers commands to import proxies and to backfill card metadata from the
-Scryfall API.
+It also offers a command to backfill card metadata from the Scryfall API.
 
 ## Setup
 
@@ -26,20 +25,19 @@ Scryfall API.
    Use `--dry-run` to see how many rows would be prepared without touching the database.
    During import, the script queries the [Scryfall API](https://scryfall.com/docs/api)
    to determine whether each card is legendary.
-3. To import proxies (cards you don't own yet), specifying their storage location and
-   automatically setting the card type to `BW Proxy` and purchase price to 0:
-   ```bash
-   python MTG_Importer.py import-proxies <path-to-csv> --location <where> \
-       --server <host[,port]> --database MTG --user <username> --password <password>
-   ```
-4. To backfill the `Legendary` flag for cards already in the database:
+   Optional parameters:
+   - `--location` (default `Bulk`)
+   - `--cardtype` (default `Original`)
+   - `--no-setpurchaseprice` to override all purchase prices with `0`
+     (default behaviour uses the value from the CSV)
+3. To backfill the `Legendary` flag for cards already in the database:
    ```bash
    python MTG_Importer.py populate-legendary --server <host[,port]> \
        --database MTG --user <username> --password <password>
    ```
 
 The script automatically selects an installed SQL Server ODBC driver. The `import`
-command assumes cards should be stored in location `Bulk` with type `Origional`. The
-`import-proxies` command requires a location and sets type to `BW Proxy`. Cards with
-"//" in their name are marked as double sided. If the Scryfall API cannot be reached,
-the `Legendary` column is left null.
+command assumes cards should be stored in location `Bulk` with type `Original` and
+uses the purchase price from the CSV unless `--no-setpurchaseprice` is given. Cards
+with "//" in their name are marked as double sided. If the Scryfall API cannot be
+reached, the `Legendary` column is left null.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ It also offers a command to backfill card metadata from the Scryfall API.
    - `--cardtype` (default `Original`)
    - `--no-setpurchaseprice` to override all purchase prices with `0`
      (default behaviour uses the value from the CSV)
+   Each imported record also sets `CreatedDate` to the current timestamp.
 3. To backfill the `Legendary` flag for cards already in the database:
    ```bash
    python MTG_Importer.py populate-legendary --server <host[,port]> \


### PR DESCRIPTION
## Summary
- drop `import-proxies` command
- allow `import` to accept optional location, card type and purchase price override
- document new options in README

## Testing
- `python MTG_Importer.py --help`
- `python MTG_Importer.py import --help`
- `python MTG_Importer.py import sample.csv --dry-run`
- `python MTG_Importer.py import sample.csv --dry-run --no-setpurchaseprice`


------
https://chatgpt.com/codex/tasks/task_e_68a0b4b7a2e8832584921da7de940327